### PR TITLE
タイトルのUnicode正規化

### DIFF
--- a/UdonChannelSetup.cs
+++ b/UdonChannelSetup.cs
@@ -102,7 +102,7 @@ public class UdonChannelSetupEditor : Editor
             {
 
                 Debug.Log($"{searchResult.Snippet.ResourceId.VideoId}, {searchResult.Snippet.Title}");
-                titles.Add($"{searchResult.Snippet.Title.Normarize()}");
+                titles.Add($"{searchResult.Snippet.Title.Normalize()}");
                 urlString.Add("https://youtu.be/" + $"{searchResult.Snippet.ResourceId.VideoId}");
 
             }

--- a/UdonChannelSetup.cs
+++ b/UdonChannelSetup.cs
@@ -102,7 +102,7 @@ public class UdonChannelSetupEditor : Editor
             {
 
                 Debug.Log($"{searchResult.Snippet.ResourceId.VideoId}, {searchResult.Snippet.Title}");
-                titles.Add($"{searchResult.Snippet.Title}");
+                titles.Add($"{searchResult.Snippet.Title.Normarize()}");
                 urlString.Add("https://youtu.be/" + $"{searchResult.Snippet.ResourceId.VideoId}");
 
             }


### PR DESCRIPTION
YouTubeから取得したタイトルはUnicode正規化されていない場合があるのでstring.Normalize()で正規化します。
例えば「が」が「か゛」のように「かな+濁点」であったりする場合があるのでこれらを「が」に変換します。
![VRChat_1920x1080_2021-05-13_21-58-54 796a](https://user-images.githubusercontent.com/57707826/118132160-5c9fa000-b43a-11eb-9f68-9d5ad8939a02.png)